### PR TITLE
Add sorting support on queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ A few transformations are already provided by the library:
 
 > [!WARNING]
 > Some features available in the PocketBase web API are not yet implemented.
-> For example, relationships, selected fields, ordering and other things are not yet supported but should be in a near future.
+> For example, relationships, selected fields and other things are not yet supported but should be in a near future.
 
 Using the repository, you can list the records in the collection using `GetRecords`:
 
@@ -221,6 +221,22 @@ var relevantPublicArticlesFilter = Filter
 var relevantPublicArticles = await articleRepository
     .Query()
     .WithFilter(relevantPublicArticlesFilter)
+    .ExecuteAsync();
+```
+
+In the same way, you can also specify how you would like your result sorted, either by directly providing the string,
+or by using the provided `SortBuilder`:
+
+```csharp
+// 👇 Equivalent to `-createdOn,name`
+var oldestFirstSort = Sort
+    .ByDescending("createdOn")
+    .ThenBy("title")
+    .Build();
+
+var articlesByCreationDate = await articleRepository
+    .Query()
+    .WithSorting(oldestFirstSort)
     .ExecuteAsync();
 ```
 

--- a/src/PocketBase.Net.Client/Entities/Repository/Query.cs
+++ b/src/PocketBase.Net.Client/Entities/Repository/Query.cs
@@ -18,4 +18,9 @@ public sealed record Query<TRecord>
     /// Pagination options for the query. Defaults to a <see cref="PaginationOptions.Default"/>.
     /// </summary>
     public PaginationOptions PaginationOptions { get; init; } = PaginationOptions.Default;
+
+    /// <summary>
+    /// Sorting to apply on the search results. Defaults to an empty string.
+    /// </summary>
+    public string Sorting { get; init; } = string.Empty;
 }

--- a/src/PocketBase.Net.Client/Entities/Repository/QueryBuilder.cs
+++ b/src/PocketBase.Net.Client/Entities/Repository/QueryBuilder.cs
@@ -1,4 +1,5 @@
-﻿using PocketBase.Net.Client.Entities.Records;
+﻿using PocketBase.Net.Client.Entities.Filter;
+using PocketBase.Net.Client.Entities.Records;
 
 namespace PocketBase.Net.Client.Entities.Repository;
 
@@ -39,6 +40,17 @@ public sealed class QueryBuilder<TRecord>(IRepository<TRecord> Repository)
     public QueryBuilder<TRecord> WithPagination(PaginationOptions paginationOptions)
     {
         _query = _query with { PaginationOptions = paginationOptions };
+        return this;
+    }
+
+    /// <summary>
+    /// Defines how the results should be sorted for the query.
+    /// </summary>
+    /// <param name="sorting">The sorting to apply.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public QueryBuilder<TRecord> WithSorting(string sorting)
+    {
+        _query = _query with { Sorting = sorting };
         return this;
     }
 

--- a/src/PocketBase.Net.Client/Entities/SortBuilder.cs
+++ b/src/PocketBase.Net.Client/Entities/SortBuilder.cs
@@ -1,0 +1,70 @@
+﻿namespace PocketBase.Net.Client.Entities;
+
+/// <summary>
+/// Represents a sort specification for ordering query results in PocketBase.
+/// This class provides a fluent interface for building sort expressions.
+/// </summary>
+public sealed class Sort
+{
+    private readonly Queue<string> _sortSections = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Sort"/> class with an initial sort field.
+    /// </summary>
+    /// <param name="seed">The initial sort field specification.</param>
+    private Sort(string seed)
+        => _sortSections.Enqueue(seed);
+
+    /// <summary>
+    /// Starts a sort specification for ascending order.
+    /// </summary>
+    /// <param name="fieldName">The name of the field to sort by.</param>
+    /// <returns>A new <see cref="Sort"/> instance configured to sort by the specified field in ascending order.</returns>
+    public static Sort By(string fieldName)
+        => new(fieldName);
+
+    /// <summary>
+    /// Starts a sort specification for descending order.
+    /// </summary>
+    /// <param name="fieldName">The name of the field to sort by.</param>
+    /// <returns>A new <see cref="Sort"/> instance configured to sort by the specified field in descending order.</returns>
+    public static Sort ByDescending(string fieldName)
+        => new(AsDescendingField(fieldName));
+
+    /// <summary>
+    /// Adds another field to sort by in ascending order.
+    /// </summary>
+    /// <param name="fieldName">The name of the additional field to sort by.</param>
+    /// <returns>The current <see cref="Sort"/> instance for method chaining.</returns>
+    public Sort ThenBy(string fieldName)
+    {
+        _sortSections.Enqueue(fieldName);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds another field to sort by in descending order.
+    /// </summary>
+    /// <param name="fieldName">The name of the additional field to sort by.</param>
+    /// <returns>The current <see cref="Sort"/> instance for method chaining.</returns>
+    public Sort ThenByDescending(string fieldName)
+    {
+        _sortSections.Enqueue(AsDescendingField(fieldName));
+        return this;
+    }
+
+    /// <summary>
+    /// Converts a field name to a descending sort field specification.
+    /// </summary>
+    /// <param name="fieldName">The field name to convert.</param>
+    /// <returns>A string representing the descending sort for the field.</returns>
+    private static string AsDescendingField(string fieldName)
+        => '-' + fieldName;
+
+    /// <summary>
+    /// Builds the final sort expression string.
+    /// </summary>
+    /// <returns>A comma-separated string representing the complete sort specification in PocketBase format.</returns>
+    public string Build()
+        => string.Join(',', _sortSections);
+}

--- a/src/PocketBase.Net.Client/IPocketBaseClient.cs
+++ b/src/PocketBase.Net.Client/IPocketBaseClient.cs
@@ -75,14 +75,16 @@ public interface IPocketBaseClient
     /// <param name="collectionIdOrName">The id or name of the collection from which the record will be retrieved.</param>
     /// <param name="filter">An optional filter to apply on the search result.</param>
     /// <param name="paginationOptions">An optional pagination on the search result.</param>
+    /// <param name="sorting">An optional sort to apply on the search result.</param>
     /// <param name="cancellation">A cancellation token to cancel the operation.</param>
     /// <returns>The retrieved records.</returns>
     Task<Paged<TRecord>> GetRecords<TRecord>(
         string collectionIdOrName,
         string? filter = null,
         PaginationOptions? paginationOptions = null,
+        string? sorting = null,
         CancellationToken cancellation = default
-     ) where TRecord : RecordBase;
+    ) where TRecord : RecordBase;
 
     /// <summary>
     /// Sends a PATCH request to the web API to a specified collection to update a given record.
@@ -147,12 +149,14 @@ public class PocketBaseClient(
         string collectionIdOrName,
         string? filter = null,
         PaginationOptions? paginationOptions = null,
+        string? sorting = null,
         CancellationToken cancellationToken = default
     ) where TRecord : RecordBase
         => httpClientWrapper.SendGet<TRecord>(
             collectionIdOrName,
             filter,
             paginationOptions,
+            sorting,
             cancellationToken);
 
     /// <inheritdoc/>

--- a/src/PocketBase.Net.Client/IRepository.cs
+++ b/src/PocketBase.Net.Client/IRepository.cs
@@ -239,7 +239,12 @@ public class Repository<TRecord>(
     public Task<Paged<TRecord>> GetRecords(
         Query<TRecord>? query,
         CancellationToken cancellationToken = default)
-        => pocketBaseClient.GetRecords<TRecord>(CollectionName, query?.Filter, query?.PaginationOptions, cancellationToken);
+        => pocketBaseClient.GetRecords<TRecord>(
+            CollectionName,
+            query?.Filter,
+            query?.PaginationOptions,
+            query?.Sorting,
+            cancellationToken);
 
     /// <inheritdoc/>
     public async Task<Paged<TRecord>?> GetRecords(

--- a/src/PocketBase.Net.Client/PocketBaseHttpClientWrapper.cs
+++ b/src/PocketBase.Net.Client/PocketBaseHttpClientWrapper.cs
@@ -50,9 +50,7 @@ public sealed class PocketBaseHttpClientWrapper(PocketBaseClientConfiguration co
 
         return toAppend.Length == 0
             ? root
-            : root + '?' + toAppend[1..].Aggregate(
-                seed: toAppend[0],
-                (current, queryParameter) => $"{current}&{queryParameter}");
+            : root + '?' + string.Join('&', toAppend);
     }
 
     /// <summary>
@@ -147,25 +145,25 @@ public sealed class PocketBaseHttpClientWrapper(PocketBaseClientConfiguration co
             onErrorThrow: (_) => new RecordSearchFailedException(),
             cancellationToken);
 
-public Task<Paged<TRecord>> SendGet<TRecord>(
-    string collectionIdOrName,
-    string? filter = null,
-    PaginationOptions? paginationOptions = null,
-    string? sorting = null,
-    CancellationToken cancellationToken = default
-) where TRecord : RecordBase
-{
-    var query = AppendQueryParameters(
-        $"/api/collections/{collectionIdOrName}/records",
-        string.IsNullOrEmpty(filter) ? null : $"filter=({filter})",
-        string.IsNullOrEmpty(sorting) ? null : $"sort={sorting}",
-        paginationOptions?.ToQueryParameters());
+    public Task<Paged<TRecord>> SendGet<TRecord>(
+        string collectionIdOrName,
+        string? filter = null,
+        PaginationOptions? paginationOptions = null,
+        string? sorting = null,
+        CancellationToken cancellationToken = default
+    ) where TRecord : RecordBase
+    {
+        var query = AppendQueryParameters(
+            $"/api/collections/{collectionIdOrName}/records",
+            string.IsNullOrEmpty(filter) ? null : $"filter=({filter})",
+            string.IsNullOrEmpty(sorting) ? null : $"sort={sorting}",
+            paginationOptions?.ToQueryParameters());
 
-    return SendRequest<Paged<TRecord>>(
-            (httpClient) => httpClient.GetAsync(query, cancellationToken),
-            onErrorThrow: (_) => new RecordSearchFailedException(),
-            cancellationToken);
-}
+        return SendRequest<Paged<TRecord>>(
+                (httpClient) => httpClient.GetAsync(query, cancellationToken),
+                onErrorThrow: (_) => new RecordSearchFailedException(),
+                cancellationToken);
+    }
 
     /// <summary>
     /// Send a PATCH request to a collection to update an existing record

--- a/src/PocketBase.Net.Client/PocketBaseHttpClientWrapper.cs
+++ b/src/PocketBase.Net.Client/PocketBaseHttpClientWrapper.cs
@@ -147,23 +147,25 @@ public sealed class PocketBaseHttpClientWrapper(PocketBaseClientConfiguration co
             onErrorThrow: (_) => new RecordSearchFailedException(),
             cancellationToken);
 
-    public Task<Paged<TRecord>> SendGet<TRecord>(
-        string collectionIdOrName,
-        string? filter = null,
-        PaginationOptions? paginationOptions = null,
-        CancellationToken cancellationToken = default
-    ) where TRecord : RecordBase
-    {
-        var query = AppendQueryParameters(
-            $"/api/collections/{collectionIdOrName}/records",
-            string.IsNullOrEmpty(filter) ? null : $"filter=({filter})",
-            paginationOptions?.ToQueryParameters());
+public Task<Paged<TRecord>> SendGet<TRecord>(
+    string collectionIdOrName,
+    string? filter = null,
+    PaginationOptions? paginationOptions = null,
+    string? sorting = null,
+    CancellationToken cancellationToken = default
+) where TRecord : RecordBase
+{
+    var query = AppendQueryParameters(
+        $"/api/collections/{collectionIdOrName}/records",
+        string.IsNullOrEmpty(filter) ? null : $"filter=({filter})",
+        string.IsNullOrEmpty(sorting) ? null : $"sort={sorting}",
+        paginationOptions?.ToQueryParameters());
 
-        return SendRequest<Paged<TRecord>>(
-                (httpClient) => httpClient.GetAsync(query, cancellationToken),
-                onErrorThrow: (_) => new RecordSearchFailedException(),
-                cancellationToken);
-    }
+    return SendRequest<Paged<TRecord>>(
+            (httpClient) => httpClient.GetAsync(query, cancellationToken),
+            onErrorThrow: (_) => new RecordSearchFailedException(),
+            cancellationToken);
+}
 
     /// <summary>
     /// Send a PATCH request to a collection to update an existing record

--- a/tests/PocketBase.Net.Client.IntegrationTests/Features/RepositoryTests.cs
+++ b/tests/PocketBase.Net.Client.IntegrationTests/Features/RepositoryTests.cs
@@ -102,24 +102,34 @@ public class RepositoryTests(PocketBaseFixture fixture)
             (todoItems) => todoItems.Items.Count.ShouldBe(1),
             (todoItems) => todoItems.Items[0].ShouldBeEquivalentTo(completedTodoItemEntity));
 
-    // Sorting results
-    var todoItemsByDescendingStatusThenByAlphabeticalOrder = await repository
-        .Query()
-        .WithSorting("-isCompleted,description")
-        .ExecuteAsync();
+        // Sorting results
+        var sortByStatusDescendingThenName = Sort
+            .ByDescending("isCompleted")
+            .ThenBy("description")
+            .Build();
 
-    todoItemsByDescendingStatusThenByAlphabeticalOrder.ShouldSatisfyAllConditions(
-        (todoItems) => todoItems.Items[0].ShouldBeEquivalentTo(completedTodoItemEntity),
-        (todoItems) => todoItems.Items[1].ShouldBeEquivalentTo(pendingTodoItemEntity));
+        var todoItemsByStatusDescendingThenName = await repository
+            .Query()
+            .WithSorting(sortByStatusDescendingThenName)
+            .ExecuteAsync();
 
-    var todoItemsByStatusThenByDescendingAlphabeticalOrder = await repository
-        .Query()
-        .WithSorting("isCompleted,-description")
-        .ExecuteAsync();
+        todoItemsByStatusDescendingThenName.ShouldSatisfyAllConditions(
+            (items) => items.Items[0].ShouldBeEquivalentTo(completedTodoItemEntity),
+            (items) => items.Items[1].ShouldBeEquivalentTo(pendingTodoItemEntity));
 
-    todoItemsByStatusThenByDescendingAlphabeticalOrder.ShouldSatisfyAllConditions(
-        (todoItems) => todoItems.Items[0].ShouldBeEquivalentTo(pendingTodoItemEntity),
-        (todoItems) => todoItems.Items[1].ShouldBeEquivalentTo(completedTodoItemEntity));
+        var sortByStatusThenNameDescending = Sort
+            .By("isCompleted")
+            .ThenByDescending("description")
+            .Build();
+
+        var todoItemsByStatusThenNameDescending = await repository
+            .Query()
+            .WithSorting(sortByStatusThenNameDescending)
+            .ExecuteAsync();
+
+        todoItemsByStatusThenNameDescending.ShouldSatisfyAllConditions(
+            (items) => items.Items[0].ShouldBeEquivalentTo(pendingTodoItemEntity),
+            (items) => items.Items[1].ShouldBeEquivalentTo(completedTodoItemEntity));
 
         // Record modification
         var updated = await repository.UpdateRecord(

--- a/tests/PocketBase.Net.Client.IntegrationTests/Features/RepositoryTests.cs
+++ b/tests/PocketBase.Net.Client.IntegrationTests/Features/RepositoryTests.cs
@@ -102,6 +102,25 @@ public class RepositoryTests(PocketBaseFixture fixture)
             (todoItems) => todoItems.Items.Count.ShouldBe(1),
             (todoItems) => todoItems.Items[0].ShouldBeEquivalentTo(completedTodoItemEntity));
 
+    // Sorting results
+    var todoItemsByDescendingStatusThenByAlphabeticalOrder = await repository
+        .Query()
+        .WithSorting("-isCompleted,description")
+        .ExecuteAsync();
+
+    todoItemsByDescendingStatusThenByAlphabeticalOrder.ShouldSatisfyAllConditions(
+        (todoItems) => todoItems.Items[0].ShouldBeEquivalentTo(completedTodoItemEntity),
+        (todoItems) => todoItems.Items[1].ShouldBeEquivalentTo(pendingTodoItemEntity));
+
+    var todoItemsByStatusThenByDescendingAlphabeticalOrder = await repository
+        .Query()
+        .WithSorting("isCompleted,-description")
+        .ExecuteAsync();
+
+    todoItemsByStatusThenByDescendingAlphabeticalOrder.ShouldSatisfyAllConditions(
+        (todoItems) => todoItems.Items[0].ShouldBeEquivalentTo(pendingTodoItemEntity),
+        (todoItems) => todoItems.Items[1].ShouldBeEquivalentTo(completedTodoItemEntity));
+
         // Record modification
         var updated = await repository.UpdateRecord(
             pendingTodoItemEntity.Id,

--- a/tests/PocketBase.Net.Client.Tests/Entities/SortBuilderTests.cs
+++ b/tests/PocketBase.Net.Client.Tests/Entities/SortBuilderTests.cs
@@ -1,0 +1,19 @@
+﻿using PocketBase.Net.Client.Entities;
+using Shouldly;
+
+namespace PocketBase.Net.Client.Tests.Entities;
+
+public class SortBuilderTests
+{
+    [Fact(DisplayName = "Build should return correct sort string for multiple fields")]
+    public void Build_ShouldReturnCorrectSortStringForMultipleFields()
+    {
+        // Arrange
+        var sort = Sort.ByDescending("name")
+            .ThenBy("age")
+            .ThenByDescending("date");
+
+        // Act & Assert
+        sort.Build().ShouldBe("-name,age,-date");
+    }
+}


### PR DESCRIPTION
This Pull Request adds the following:

- Add a `WithSorting` on queries (+ integration test)
- Add a `SortBuilder` to create sorting strings (+ unit tests)
- Update the README on how to use sorting with queries

Closes #5 